### PR TITLE
Fix bug in the cases of 113..120

### DIFF
--- a/lib/ordinalize.rb
+++ b/lib/ordinalize.rb
@@ -46,6 +46,14 @@ module Ordinalize
       "ten" => "tenth",
       "eleven" => "eleventh", 
       "twelve" => "twelveth",
+      "thirteen" => "thirteenth",
+      "fourteen" => "fourteenth",
+      "fifteen" => "fifteenth",
+      "sixteen" => "sixteenth",
+      "seventeen" => "seventeenth",
+      "eighteen" => "eighteenth",
+      "nineteen" => "nineteenth",
+      "twenty" => "twentieth"
     }
   end
 end

--- a/spec/ordinalize_spec.rb
+++ b/spec/ordinalize_spec.rb
@@ -31,6 +31,15 @@ describe "Ordinalize" do
    [27, "twenty-seventh"],
    [28, "twenty-eighth"],
    [29, "twenty-ninth"],
+   [113, "one hundred and thirteenth"],
+   [115, "one hundred and fifteenth"],
+   [116, "one hundred and sixteenth"],
+   [117, "one hundred and seventeenth"],
+   [118, "one hundred and eighteenth"],
+   [119, "one hundred and nineteenth"],
+   [120, "one hundred and twentieth"],
+   [121, "one hundred and twenty-first"],
+   [122, "one hundred and twenty-second"],
    [1005, "one thousand and fifth"],
    [1024, "one thousand and twenty-fourth"]
   ].each do |num, expected|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,4 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'ordinalize'
-require 'spec'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-  
-end
+require 'rspec'


### PR DESCRIPTION
These numbers were being ordinalized to "one hundred and".

If fixed this by adding some key-value pairs to the conversions hash.
