### PR TITLE
Ordinalize vs ordinalise nuances

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ From the creator who brought you the wildly popular [humanize](http://github.com
 # Usage
 
     >> 1.ordinalize
-    => "first"
+    => "1st"
     
     >> 1024.ordinalize
     => "one thousand and twenty-fourth"


### PR DESCRIPTION
ordinalize returns numeric with ending whereas ordinalise returns exclusively text.
This little differentiation caused me to search on google for about an hour until I realized that your gem did both, but the readme file was wrong.
